### PR TITLE
URL button display correction

### DIFF
--- a/items/show.php
+++ b/items/show.php
@@ -110,7 +110,7 @@
     </div>
     <?php endif; ?>
 
-    <?php if ($url = metadata('item',array('Item Type Metadata', 'URL'))): ?>
+    <?php if (isset(item_type_elements()["URL"]) and (trim(item_type_elements()["URL"]) !== "")): ?>
       <div class="col-sm-12">
         <a href="<?php echo $url; ?>" target="_blank" class="btn btn-outline-primary">Ver en Biblioteca Nacional</a>
       </div>


### PR DESCRIPTION
Corrección para que los elementos que NO tienen una URL, nunca muestren el botón de "Ver en Biblioteca Nacional". En la línea 113, se cambia la función metadara() para obtener el contenido del campo "URL", por la función item_type_elements().